### PR TITLE
Add support for (DSD) WavPack

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rusqlite = { version = "0.25.0", features = ["bundled"] }
 log = "0.4.14"
 env_logger = "0.8.4"
 indicatif = "0.16.2"
-lofty = "0.15.0"
+lofty = "0.16.0"
 dirs = "1"
 chrono = "0.4.19"
 regex = "1"

--- a/src/analyse.rs
+++ b/src/analyse.rs
@@ -23,7 +23,7 @@ use num_cpus;
 const DONT_ANALYSE: &str = ".notmusic";
 const MAX_ERRORS_TO_SHOW: usize = 100;
 const MAX_TAG_ERRORS_TO_SHOW: usize = 50;
-const VALID_EXTENSIONS: [&str; 5] = ["m4a", "mp3", "ogg", "flac", "opus"];
+const VALID_EXTENSIONS: [&str; 6] = ["m4a", "mp3", "ogg", "flac", "opus", "wv"];
 
 fn get_file_list(db: &mut db::Db, mpath: &Path, path: &Path, track_paths: &mut Vec<String>) {
     if !path.is_dir() {


### PR DESCRIPTION
- Added wv as valid extension
- lofty had incorrect duration scanning for DSD Wavpack in version 0.15.0, so version bumped to 0.16.0

Tested on a small collection of test files. A DSD file resampled to PCM gave comparable analysis values within 0,2% of each other, except MeanLoudness and StdDevLoudness (DSD files had 30% lower loudness), but that could maybe be an artifact of the resampling.