### PR TITLE
Convert analysis to 15 significant digits prior to handing to SQLite.…

### DIFF
--- a/src/analyse.rs
+++ b/src/analyse.rs
@@ -44,7 +44,7 @@ const MAX_ERRORS_TO_SHOW: usize = 100;
 const MAX_TAG_ERRORS_TO_SHOW: usize = 50;
 const VALID_EXTENSIONS: [&str; 7] = ["m4a", "mp3", "ogg", "flac", "opus", "wv", "dsf"];
 
-fn get_file_list(db: &mut db::Db, mpath: &Path, path: &Path, track_paths: &mut Vec<String>, cue_tracks:&mut Vec<cue::CueTrack>, file_count:&mut usize, max_num_files: usize, read_tags: bool, tagged_file_count:&mut usize, dry_run: bool) {
+fn get_file_list(db: &mut db::Db, mpath: &Path, path: &Path, track_paths: &mut Vec<String>, cue_tracks:&mut Vec<cue::CueTrack>, file_count:&mut usize, max_num_files: usize, read_tags: bool, tagged_file_count:&mut usize, dry_run: bool, prefer_tags: bool) {
     if !path.is_dir() {
         return;
     }
@@ -53,23 +53,26 @@ fn get_file_list(db: &mut db::Db, mpath: &Path, path: &Path, track_paths: &mut V
     items.sort_by_key(|dir| dir.path());
 
     for item in items {
-        check_dir_entry(db, mpath, item, track_paths, cue_tracks, file_count, max_num_files, read_tags, tagged_file_count, dry_run);
+        check_dir_entry(db, mpath, item, track_paths, cue_tracks, file_count, max_num_files, read_tags, tagged_file_count, dry_run, prefer_tags);
         if max_num_files>0 && *file_count>=max_num_files {
             break;
         }
     }
 }
 
-fn check_dir_entry(db: &mut db::Db, mpath: &Path, entry: DirEntry, track_paths: &mut Vec<String>, cue_tracks:&mut Vec<cue::CueTrack>, file_count:&mut usize, max_num_files: usize, read_tags: bool, tagged_file_count:&mut usize, dry_run: bool) {
+fn check_dir_entry(db: &mut db::Db, mpath: &Path, entry: DirEntry, track_paths: &mut Vec<String>, cue_tracks: &mut Vec<cue::CueTrack>, 
+                  file_count: &mut usize, max_num_files: usize, read_tags: bool, tagged_file_count: &mut usize, 
+                  dry_run: bool, prefer_tags: bool) {
+
     let pb = entry.path();
     if pb.is_dir() {
         let check = pb.join(DONT_ANALYSE);
         if check.exists() {
             log::info!("Skipping '{}', found '{}'", pb.to_string_lossy(), DONT_ANALYSE);
         } else if max_num_files<=0 || *file_count<max_num_files {
-            get_file_list(db, mpath, &pb, track_paths, cue_tracks, file_count, max_num_files, read_tags, tagged_file_count, dry_run);
+            get_file_list(db, mpath, &pb, track_paths, cue_tracks, file_count, max_num_files, read_tags, tagged_file_count, dry_run, prefer_tags);
         }
-    } else if pb.is_file() && (max_num_files<=0 || *file_count<max_num_files) {
+    } else if pb.is_file() && (max_num_files <= 0 || *file_count < max_num_files) {
         if_chain! {
             if let Some(ext) = pb.extension();
             let ext = ext.to_string_lossy();
@@ -79,6 +82,19 @@ fn check_dir_entry(db: &mut db::Db, mpath: &Path, entry: DirEntry, track_paths: 
                 let sname = String::from(stripped.to_string_lossy());
                 let mut cue_file = pb.clone();
                 cue_file.set_extension("cue");
+
+                // Check if we should prefer tags
+                if prefer_tags {
+                    let meta = tags::read(&String::from(pb.to_string_lossy()), true);
+                    if !meta.is_empty() && meta.analysis.is_some() {
+                        if !dry_run {
+                            db.add_track(&sname, &meta, &meta.analysis.unwrap());
+                        }
+                        *tagged_file_count += 1;
+                        return; // Skip further processing
+                    }
+                }
+
                 if cue_file.exists() {
                     // For cue files, check if first track is in DB
                     let mut cue_track_path = pb.clone();
@@ -404,7 +420,9 @@ fn analyse_new_cue_tracks(db:&db::Db, mpath: &PathBuf, cue_tracks:Vec<cue::CueTr
     Ok(())
 }
 
-pub fn analyse_files(db_path: &str, mpaths: &Vec<PathBuf>, dry_run: bool, keep_old: bool, max_num_files: usize, max_threads: usize, ignore_path: &PathBuf, read_tags: bool, write_tags: bool, preserve_mod_times: bool) {
+pub fn analyse_files(db_path: &str, mpaths: &Vec<PathBuf>, dry_run: bool, keep_old: bool, max_num_files: usize, 
+                    max_threads: usize, ignore_path: &PathBuf, read_tags: bool, write_tags: bool, 
+                    preserve_mod_times: bool, prefer_tags: bool) {
     let mut db = db::Db::new(&String::from(db_path));
 
     db.init();
@@ -422,12 +440,17 @@ pub fn analyse_files(db_path: &str, mpaths: &Vec<PathBuf>, dry_run: bool, keep_o
         let mut file_count:usize = 0;
         let mut tagged_file_count:usize = 0;
 
+        get_file_list(&mut db, &mpath, &cur, &mut track_paths, &mut cue_tracks, 
+                     &mut file_count, max_num_files, read_tags, &mut tagged_file_count, 
+                     dry_run, prefer_tags);
+
+
         if mpaths.len() > 1 {
             log::info!("Looking for new files in {}", mpath.to_string_lossy());
         } else {
             log::info!("Looking for new files");
         }
-        get_file_list(&mut db, &mpath, &cur, &mut track_paths, &mut cue_tracks, &mut file_count, max_num_files, read_tags, &mut tagged_file_count, dry_run);
+        get_file_list(&mut db, &mpath, &cur, &mut track_paths, &mut cue_tracks, &mut file_count, max_num_files, read_tags, &mut tagged_file_count, dry_run, prefer_tags);
         track_paths.sort();
         if read_tags {
             log::info!("New untagged files: {}", track_paths.len());

--- a/src/db.rs
+++ b/src/db.rs
@@ -148,6 +148,44 @@ impl Db {
         Ok(rowid)
     }
 
+    // pub fn add_track(&self, path: &String, meta: &Metadata, analysis: &Analysis) {
+    //     let mut db_path = path.clone();
+    //     if cfg!(windows) {
+    //         db_path = db_path.replace("\\", "/");
+    //     }
+    //     match self.get_rowid(&path) {
+    //         Ok(id) => {
+    //             if id <= 0 {
+    //                 match self.conn.execute("INSERT INTO Tracks (File, Title, Artist, AlbumArtist, Album, Genre, Duration, Ignore, Tempo, Zcr, MeanSpectralCentroid, StdDevSpectralCentroid, MeanSpectralRolloff, StdDevSpectralRolloff, MeanSpectralFlatness, StdDevSpectralFlatness, MeanLoudness, StdDevLoudness, Chroma1, Chroma2, Chroma3, Chroma4, Chroma5, Chroma6, Chroma7, Chroma8, Chroma9, Chroma10) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
+    //                         params![db_path, meta.title, meta.artist, meta.album_artist, meta.album, meta.genre, meta.duration, 0,
+    //                         analysis[AnalysisIndex::Tempo], analysis[AnalysisIndex::Zcr], analysis[AnalysisIndex::MeanSpectralCentroid], analysis[AnalysisIndex::StdDeviationSpectralCentroid], analysis[AnalysisIndex::MeanSpectralRolloff],
+    //                         analysis[AnalysisIndex::StdDeviationSpectralRolloff], analysis[AnalysisIndex::MeanSpectralFlatness], analysis[AnalysisIndex::StdDeviationSpectralFlatness], analysis[AnalysisIndex::MeanLoudness], analysis[AnalysisIndex::StdDeviationLoudness],
+    //                         analysis[AnalysisIndex::Chroma1], analysis[AnalysisIndex::Chroma2], analysis[AnalysisIndex::Chroma3], analysis[AnalysisIndex::Chroma4], analysis[AnalysisIndex::Chroma5],
+    //                         analysis[AnalysisIndex::Chroma6], analysis[AnalysisIndex::Chroma7], analysis[AnalysisIndex::Chroma8], analysis[AnalysisIndex::Chroma9], analysis[AnalysisIndex::Chroma10]]) {
+    //                     Ok(_) => { }
+    //                     Err(e) => { log::error!("Failed to insert '{}' into database. {}", path, e); }
+    //                 }
+    //             } else {
+    //                 match self.conn.execute("UPDATE Tracks SET Title=?, Artist=?, AlbumArtist=?, Album=?, Genre=?, Duration=?, Tempo=?, Zcr=?, MeanSpectralCentroid=?, StdDevSpectralCentroid=?, MeanSpectralRolloff=?, StdDevSpectralRolloff=?, MeanSpectralFlatness=?, StdDevSpectralFlatness=?, MeanLoudness=?, StdDevLoudness=?, Chroma1=?, Chroma2=?, Chroma3=?, Chroma4=?, Chroma5=?, Chroma6=?, Chroma7=?, Chroma8=?, Chroma9=?, Chroma10=? WHERE rowid=?;",
+    //                         params![meta.title, meta.artist, meta.album_artist, meta.album, meta.genre, meta.duration,
+    //                         analysis[AnalysisIndex::Tempo], analysis[AnalysisIndex::Zcr], analysis[AnalysisIndex::MeanSpectralCentroid], analysis[AnalysisIndex::StdDeviationSpectralCentroid], analysis[AnalysisIndex::MeanSpectralRolloff],
+    //                         analysis[AnalysisIndex::StdDeviationSpectralRolloff], analysis[AnalysisIndex::MeanSpectralFlatness], analysis[AnalysisIndex::StdDeviationSpectralFlatness], analysis[AnalysisIndex::MeanLoudness], analysis[AnalysisIndex::StdDeviationLoudness],
+    //                         analysis[AnalysisIndex::Chroma1], analysis[AnalysisIndex::Chroma2], analysis[AnalysisIndex::Chroma3], analysis[AnalysisIndex::Chroma4], analysis[AnalysisIndex::Chroma5],
+    //                         analysis[AnalysisIndex::Chroma6], analysis[AnalysisIndex::Chroma7], analysis[AnalysisIndex::Chroma8], analysis[AnalysisIndex::Chroma9], analysis[AnalysisIndex::Chroma10], id]) {
+    //                     Ok(_) => { }
+    //                     Err(e) => { log::error!("Failed to update '{}' in database. {}", path, e); }
+    //                 }
+    //             }
+    //         }
+    //         Err(_) => { }
+    //     }
+
+    fn format_float(val: f32) -> f32 {
+        // Format with 15 significant digits and parse back to ensure consistency
+        let s = format!("{:.15}", val);
+        s.parse().unwrap_or(val)
+    }
+
     pub fn add_track(&self, path: &String, meta: &Metadata, analysis: &Analysis) {
         let mut db_path = path.clone();
         if cfg!(windows) {
@@ -158,20 +196,52 @@ impl Db {
                 if id <= 0 {
                     match self.conn.execute("INSERT INTO Tracks (File, Title, Artist, AlbumArtist, Album, Genre, Duration, Ignore, Tempo, Zcr, MeanSpectralCentroid, StdDevSpectralCentroid, MeanSpectralRolloff, StdDevSpectralRolloff, MeanSpectralFlatness, StdDevSpectralFlatness, MeanLoudness, StdDevLoudness, Chroma1, Chroma2, Chroma3, Chroma4, Chroma5, Chroma6, Chroma7, Chroma8, Chroma9, Chroma10) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
                             params![db_path, meta.title, meta.artist, meta.album_artist, meta.album, meta.genre, meta.duration, 0,
-                            analysis[AnalysisIndex::Tempo], analysis[AnalysisIndex::Zcr], analysis[AnalysisIndex::MeanSpectralCentroid], analysis[AnalysisIndex::StdDeviationSpectralCentroid], analysis[AnalysisIndex::MeanSpectralRolloff],
-                            analysis[AnalysisIndex::StdDeviationSpectralRolloff], analysis[AnalysisIndex::MeanSpectralFlatness], analysis[AnalysisIndex::StdDeviationSpectralFlatness], analysis[AnalysisIndex::MeanLoudness], analysis[AnalysisIndex::StdDeviationLoudness],
-                            analysis[AnalysisIndex::Chroma1], analysis[AnalysisIndex::Chroma2], analysis[AnalysisIndex::Chroma3], analysis[AnalysisIndex::Chroma4], analysis[AnalysisIndex::Chroma5],
-                            analysis[AnalysisIndex::Chroma6], analysis[AnalysisIndex::Chroma7], analysis[AnalysisIndex::Chroma8], analysis[AnalysisIndex::Chroma9], analysis[AnalysisIndex::Chroma10]]) {
+                            Self::format_float(analysis[AnalysisIndex::Tempo]), 
+                            Self::format_float(analysis[AnalysisIndex::Zcr]), 
+                            Self::format_float(analysis[AnalysisIndex::MeanSpectralCentroid]), 
+                            Self::format_float(analysis[AnalysisIndex::StdDeviationSpectralCentroid]), 
+                            Self::format_float(analysis[AnalysisIndex::MeanSpectralRolloff]),
+                            Self::format_float(analysis[AnalysisIndex::StdDeviationSpectralRolloff]), 
+                            Self::format_float(analysis[AnalysisIndex::MeanSpectralFlatness]), 
+                            Self::format_float(analysis[AnalysisIndex::StdDeviationSpectralFlatness]), 
+                            Self::format_float(analysis[AnalysisIndex::MeanLoudness]), 
+                            Self::format_float(analysis[AnalysisIndex::StdDeviationLoudness]),
+                            Self::format_float(analysis[AnalysisIndex::Chroma1]), 
+                            Self::format_float(analysis[AnalysisIndex::Chroma2]), 
+                            Self::format_float(analysis[AnalysisIndex::Chroma3]), 
+                            Self::format_float(analysis[AnalysisIndex::Chroma4]), 
+                            Self::format_float(analysis[AnalysisIndex::Chroma5]),
+                            Self::format_float(analysis[AnalysisIndex::Chroma6]), 
+                            Self::format_float(analysis[AnalysisIndex::Chroma7]), 
+                            Self::format_float(analysis[AnalysisIndex::Chroma8]), 
+                            Self::format_float(analysis[AnalysisIndex::Chroma9]), 
+                            Self::format_float(analysis[AnalysisIndex::Chroma10])]) {
                         Ok(_) => { }
                         Err(e) => { log::error!("Failed to insert '{}' into database. {}", path, e); }
                     }
                 } else {
                     match self.conn.execute("UPDATE Tracks SET Title=?, Artist=?, AlbumArtist=?, Album=?, Genre=?, Duration=?, Tempo=?, Zcr=?, MeanSpectralCentroid=?, StdDevSpectralCentroid=?, MeanSpectralRolloff=?, StdDevSpectralRolloff=?, MeanSpectralFlatness=?, StdDevSpectralFlatness=?, MeanLoudness=?, StdDevLoudness=?, Chroma1=?, Chroma2=?, Chroma3=?, Chroma4=?, Chroma5=?, Chroma6=?, Chroma7=?, Chroma8=?, Chroma9=?, Chroma10=? WHERE rowid=?;",
                             params![meta.title, meta.artist, meta.album_artist, meta.album, meta.genre, meta.duration,
-                            analysis[AnalysisIndex::Tempo], analysis[AnalysisIndex::Zcr], analysis[AnalysisIndex::MeanSpectralCentroid], analysis[AnalysisIndex::StdDeviationSpectralCentroid], analysis[AnalysisIndex::MeanSpectralRolloff],
-                            analysis[AnalysisIndex::StdDeviationSpectralRolloff], analysis[AnalysisIndex::MeanSpectralFlatness], analysis[AnalysisIndex::StdDeviationSpectralFlatness], analysis[AnalysisIndex::MeanLoudness], analysis[AnalysisIndex::StdDeviationLoudness],
-                            analysis[AnalysisIndex::Chroma1], analysis[AnalysisIndex::Chroma2], analysis[AnalysisIndex::Chroma3], analysis[AnalysisIndex::Chroma4], analysis[AnalysisIndex::Chroma5],
-                            analysis[AnalysisIndex::Chroma6], analysis[AnalysisIndex::Chroma7], analysis[AnalysisIndex::Chroma8], analysis[AnalysisIndex::Chroma9], analysis[AnalysisIndex::Chroma10], id]) {
+                            Self::format_float(analysis[AnalysisIndex::Tempo]), 
+                            Self::format_float(analysis[AnalysisIndex::Zcr]), 
+                            Self::format_float(analysis[AnalysisIndex::MeanSpectralCentroid]), 
+                            Self::format_float(analysis[AnalysisIndex::StdDeviationSpectralCentroid]), 
+                            Self::format_float(analysis[AnalysisIndex::MeanSpectralRolloff]),
+                            Self::format_float(analysis[AnalysisIndex::StdDeviationSpectralRolloff]), 
+                            Self::format_float(analysis[AnalysisIndex::MeanSpectralFlatness]), 
+                            Self::format_float(analysis[AnalysisIndex::StdDeviationSpectralFlatness]), 
+                            Self::format_float(analysis[AnalysisIndex::MeanLoudness]), 
+                            Self::format_float(analysis[AnalysisIndex::StdDeviationLoudness]),
+                            Self::format_float(analysis[AnalysisIndex::Chroma1]), 
+                            Self::format_float(analysis[AnalysisIndex::Chroma2]), 
+                            Self::format_float(analysis[AnalysisIndex::Chroma3]), 
+                            Self::format_float(analysis[AnalysisIndex::Chroma4]), 
+                            Self::format_float(analysis[AnalysisIndex::Chroma5]),
+                            Self::format_float(analysis[AnalysisIndex::Chroma6]), 
+                            Self::format_float(analysis[AnalysisIndex::Chroma7]), 
+                            Self::format_float(analysis[AnalysisIndex::Chroma8]), 
+                            Self::format_float(analysis[AnalysisIndex::Chroma9]), 
+                            Self::format_float(analysis[AnalysisIndex::Chroma10]), id]) {
                         Ok(_) => { }
                         Err(e) => { log::error!("Failed to update '{}' in database. {}", path, e); }
                     }
@@ -180,6 +250,8 @@ impl Db {
             Err(_) => { }
         }
     }
+
+
 
     pub fn remove_old(&self, mpaths: &Vec<PathBuf>, dry_run: bool) {
         log::info!("Looking for non-existent tracks");

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,9 @@ fn main() {
     let mut read_tags = false;
     let mut write_tags = false;
     let mut preserve_mod_times = false;
+    let mut prefer_tags = false;
+
+
 
     match dirs::home_dir() {
         Some(path) => {
@@ -83,6 +86,7 @@ fn main() {
         arg_parse.refer(&mut use_tags).add_option(&["-T", "--tags"], StoreTrue, "Read tags if present, and write tags if not present - this option is the same as supplying both --read-tags and --write-tags");
         arg_parse.refer(&mut preserve_mod_times).add_option(&["-p", "--preserve"], StoreTrue, "Preserve modification time when writing tags to files");
         arg_parse.refer(&mut task).add_argument("task", Store, "Task to perform; analyse, tags, ignore, upload, export, stopmixer.");
+        arg_parse.refer(&mut prefer_tags).add_option(&["-P", "--prefer-tags"], StoreTrue, "Prefer existing tags over analysis (faster)");
         arg_parse.parse_args_or_exit();
     }
 
@@ -228,7 +232,7 @@ fn main() {
                 db::export(&db_path, &music_paths, max_threads, preserve_mod_times);
             } else {
                 let ignore_path = PathBuf::from(&ignore_file);
-                analyse::analyse_files(&db_path, &music_paths, dry_run, keep_old, max_num_files, max_threads, &ignore_path, use_tags||read_tags, use_tags||write_tags, preserve_mod_times);
+                analyse::analyse_files(&db_path, &music_paths, dry_run, keep_old, max_num_files, max_threads, &ignore_path, use_tags||read_tags, use_tags||write_tags, preserve_mod_times, prefer_tags);
             }
         }
     }

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -25,11 +25,33 @@ const ANALYSIS_TAG: &str = "BLISS_ANALYSIS";
 const ANALYSIS_TAG_VER: u16 = 1;
 
 pub fn write_analysis(track: &String, analysis: &Analysis, preserve_mod_times: bool) -> bool {
-    let value = format!("{},{:.24},{:.24},{:.24},{:.24},{:.24},{:.24},{:.24},{:.24},{:.24},{:.24},{:.24},{:.24},{:.24},{:.24},{:.24},{:.24},{:.24},{:.24},{:.24},{:.24}", ANALYSIS_TAG_VER,
-                        analysis[AnalysisIndex::Tempo], analysis[AnalysisIndex::Zcr], analysis[AnalysisIndex::MeanSpectralCentroid], analysis[AnalysisIndex::StdDeviationSpectralCentroid], analysis[AnalysisIndex::MeanSpectralRolloff],
-                        analysis[AnalysisIndex::StdDeviationSpectralRolloff], analysis[AnalysisIndex::MeanSpectralFlatness], analysis[AnalysisIndex::StdDeviationSpectralFlatness], analysis[AnalysisIndex::MeanLoudness], analysis[AnalysisIndex::StdDeviationLoudness],
-                        analysis[AnalysisIndex::Chroma1], analysis[AnalysisIndex::Chroma2], analysis[AnalysisIndex::Chroma3], analysis[AnalysisIndex::Chroma4], analysis[AnalysisIndex::Chroma5],
-                        analysis[AnalysisIndex::Chroma6], analysis[AnalysisIndex::Chroma7], analysis[AnalysisIndex::Chroma8], analysis[AnalysisIndex::Chroma9], analysis[AnalysisIndex::Chroma10]);
+//     let value = format!("{},{:.24},{:.24},{:.24},{:.24},{:.24},{:.24},{:.24},{:.24},{:.24},{:.24},{:.24},{:.24},{:.24},{:.24},{:.24},{:.24},{:.24},{:.24},{:.24},{:.24}", ANALYSIS_TAG_VER,
+//                         analysis[AnalysisIndex::Tempo], analysis[AnalysisIndex::Zcr], analysis[AnalysisIndex::MeanSpectralCentroid], analysis[AnalysisIndex::StdDeviationSpectralCentroid], analysis[AnalysisIndex::MeanSpectralRolloff],
+//                         analysis[AnalysisIndex::StdDeviationSpectralRolloff], analysis[AnalysisIndex::MeanSpectralFlatness], analysis[AnalysisIndex::StdDeviationSpectralFlatness], analysis[AnalysisIndex::MeanLoudness], analysis[AnalysisIndex::StdDeviationLoudness],
+//                         analysis[AnalysisIndex::Chroma1], analysis[AnalysisIndex::Chroma2], analysis[AnalysisIndex::Chroma3], analysis[AnalysisIndex::Chroma4], analysis[AnalysisIndex::Chroma5],
+//                         analysis[AnalysisIndex::Chroma6], analysis[AnalysisIndex::Chroma7], analysis[AnalysisIndex::Chroma8], analysis[AnalysisIndex::Chroma9], analysis[AnalysisIndex::Chroma10]);
+
+    let value = format!("{},{:.15},{:.15},{:.15},{:.15},{:.15},{:.15},{:.15},{:.15},{:.15},{:.15},{:.15},{:.15},{:.15},{:.15},{:.15},{:.15},{:.15},{:.15},{:.15},{:.15}", ANALYSIS_TAG_VER,
+                        analysis[AnalysisIndex::Tempo], 
+                        analysis[AnalysisIndex::Zcr], 
+                        analysis[AnalysisIndex::MeanSpectralCentroid], 
+                        analysis[AnalysisIndex::StdDeviationSpectralCentroid], 
+                        analysis[AnalysisIndex::MeanSpectralRolloff],
+                        analysis[AnalysisIndex::StdDeviationSpectralRolloff], 
+                        analysis[AnalysisIndex::MeanSpectralFlatness], 
+                        analysis[AnalysisIndex::StdDeviationSpectralFlatness], 
+                        analysis[AnalysisIndex::MeanLoudness], 
+                        analysis[AnalysisIndex::StdDeviationLoudness],
+                        analysis[AnalysisIndex::Chroma1], 
+                        analysis[AnalysisIndex::Chroma2], 
+                        analysis[AnalysisIndex::Chroma3], 
+                        analysis[AnalysisIndex::Chroma4], 
+                        analysis[AnalysisIndex::Chroma5],
+                        analysis[AnalysisIndex::Chroma6], 
+                        analysis[AnalysisIndex::Chroma7], 
+                        analysis[AnalysisIndex::Chroma8], 
+                        analysis[AnalysisIndex::Chroma9], 
+                        analysis[AnalysisIndex::Chroma10]);
 
     let mut written = false;
     if let Ok(mut file) = lofty::read_from_path(Path::new(track)) {
@@ -74,6 +96,49 @@ pub fn write_analysis(track: &String, analysis: &Analysis, preserve_mod_times: b
     written
 }
 
+// fn read_analysis_string(tag_str: &str, start_tag_pos:usize, version_pos:usize) -> Option<Analysis> {
+//     let parts = tag_str.split(",");
+//     let mut index = 0;
+//     let mut num_read_vals = 0;
+//     let mut vals = [0.; NUM_ANALYSIS_VALS];
+//     let val_start_pos = version_pos+1;
+//     for part in parts {
+//         if index==start_tag_pos && start_tag_pos<version_pos {
+//             if part!=ANALYSIS_TAG {
+//                 break;
+//             }
+//         } else if index==version_pos {
+//             match part.parse::<u16>() {
+//                 Ok(ver) => {
+//                     if ver!=ANALYSIS_TAG_VER {
+//                         break;
+//                     }
+//                 },
+//                 Err(_) => {
+//                     break;
+//                 }
+//             }
+//         } else if (index - val_start_pos) < NUM_ANALYSIS_VALS {
+//             match part.parse::<f32>() {
+//                 Ok(val) => {
+//                     num_read_vals += 1;
+//                     vals[index - val_start_pos] = val;
+//                 },
+//                 Err(_) => {
+//                     break;
+//                 }
+//             }
+//         } else {
+//             break;
+//         }
+//         index += 1;
+//     }
+//     if num_read_vals == NUM_ANALYSIS_VALS {
+//         return Some(Analysis::new(vals));
+//     }
+//     None
+// }
+
 fn read_analysis_string(tag_str: &str, start_tag_pos:usize, version_pos:usize) -> Option<Analysis> {
     let parts = tag_str.split(",");
     let mut index = 0;
@@ -100,7 +165,9 @@ fn read_analysis_string(tag_str: &str, start_tag_pos:usize, version_pos:usize) -
             match part.parse::<f32>() {
                 Ok(val) => {
                     num_read_vals += 1;
-                    vals[index - val_start_pos] = val;
+                    // Format with 15 significant digits to ensure consistency
+                    let s = format!("{:.15}", val);
+                    vals[index - val_start_pos] = s.parse().unwrap_or(val);
                 },
                 Err(_) => {
                     break;


### PR DESCRIPTION
…  Handle as 15 significant digits when read in from Tracks.  Add --prefer_tags to ingest analysis from tags to build db.

I'm not a Rust developer, but have attempted the following changes for your consideration:

1. Before writing analysis results to SQLite table, the results are converted to 15 significant digits within Rust rather than relying on SQLite.  This ensures the results written to and read from Tracks are identical because Rust is handling the conversion in both directions.
2. Added ability to build bliss.db by referencing values from tags bypassing all analysis.